### PR TITLE
fix: 회원 API JWT 인증 미적용 문제 수정

### DIFF
--- a/src/main/java/com/nhnacademy/byeol23backend/commons/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nhnacademy/byeol23backend/commons/filters/JwtAuthenticationFilter.java
@@ -33,29 +33,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if(token != null && token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        try {
-            Claims claims = jwtParser.parseToken(token);
+        // Bearer 토큰이 있을 때만 인증을 시도한다. (공개 자원 요청은 토큰 없이 통과)
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Claims claims = jwtParser.parseToken(token);
 
-            Long memberId = claims.get("memberId", Long.class);
-            String role = claims.get("role", String.class); // "USER", "ADMIN" 등
+                Long memberId = claims.get("memberId", Long.class);
+                String role = claims.get("role", String.class); // "USER", "ADMIN" 등
 
-            if (memberId != null && role != null) {
-                var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+                if (memberId != null && role != null) {
+                    var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
-                Authentication authentication =
-                        new UsernamePasswordAuthenticationToken(memberId, null, authorities);
+                    Authentication authentication =
+                            new UsernamePasswordAuthenticationToken(memberId, null, authorities);
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (Exception e) {
+                // 토큰이 유효하지 않으면 인증을 채우지 않고 넘긴다.
+                // 보호 자원이면 SecurityConfig가 EntryPoint를 통해 401을 반환한다.
+                log.warn("JWT 인증 필터 - 토큰 파싱 실패: {}", e.getMessage());
             }
-        } catch (Exception e) {
-            log.warn("JWT 인증 필터 - 토큰 파싱 실패: {}", e.getMessage());
         }
-
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/nhnacademy/byeol23backend/commons/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/nhnacademy/byeol23backend/commons/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.byeol23backend.commons.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 인증이 필요한 엔드포인트에 유효한 JWT 없이 접근했을 때 401(JSON)을 반환한다.
+ * <p>SecurityContext에 인증 정보가 채워지지 않은 채 보호 자원에 도달하면 호출된다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(),
+                Map.of("status", HttpStatus.UNAUTHORIZED.value(), "message", "인증이 필요합니다."));
+    }
+}

--- a/src/main/java/com/nhnacademy/byeol23backend/config/SecurityConfig.java
+++ b/src/main/java/com/nhnacademy/byeol23backend/config/SecurityConfig.java
@@ -1,9 +1,11 @@
 package com.nhnacademy.byeol23backend.config;
 
 import com.nhnacademy.byeol23backend.commons.filters.JwtAuthenticationFilter;
+import com.nhnacademy.byeol23backend.commons.security.RestAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -16,10 +18,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -28,11 +33,16 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/categories/**"
-                        ).permitAll()
+                        // 인증 없이 접근 가능한 회원 엔드포인트 (회원가입 / 중복 확인)
+                        .requestMatchers(HttpMethod.POST, "/api/members").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/check-id").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/members/check-duplication").permitAll()
+                        // 그 외 회원 관련 엔드포인트는 로그인(JWT) 필요
+                        .requestMatchers("/api/members/**").authenticated()
+                        // 상품/카테고리 등 나머지 자원은 공개
                         .anyRequest().permitAll()
                 )
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(restAuthenticationEntryPoint))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();


### PR DESCRIPTION
## 요약
- SecurityConfig에서 `anyRequest().permitAll()`로 인해 회원 관련 API가 인증 없이 호출 가능했던 문제 수정
- `/api/members/**`는 인증을 요구하도록 변경 (회원가입, 아이디/정보 중복확인은 그대로 공개)
- 미인증 접근 시 500 대신 401 JSON을 반환하는 RestAuthenticationEntryPoint 추가
- JwtAuthenticationFilter: Bearer 토큰이 있을 때만 인증 시도하도록 정리

## 테스트
- 로컬(Docker MySQL/Redis + auth/gateway/back 실기동)에서 검증
  - 토큰 없이 `GET /api/members` → 401
  - 위조 토큰으로 `GET /api/members` → 401
  - 공개 엔드포인트(`check-id`) → 200 (과잉 차단 아님 확인)
  - 유효 토큰으로 `GET /api/members` → 200 + 회원정보 정상 반환